### PR TITLE
BSIA-265 #comment Added mp3 file extension to allowable extensions fo…

### DIFF
--- a/config/sync/core.entity_view_display.node.blog.rss.yml
+++ b/config/sync/core.entity_view_display.node.blog.rss.yml
@@ -37,3 +37,5 @@ content:
     weight: 100
 hidden:
   body: true
+  field_caption: true
+  upload: true

--- a/config/sync/core.entity_view_display.node.blog.search_index.yml
+++ b/config/sync/core.entity_view_display.node.blog.search_index.yml
@@ -37,3 +37,5 @@ content:
     weight: 100
 hidden:
   body: true
+  field_caption: true
+  upload: true

--- a/config/sync/core.entity_view_display.node.blog.search_result.yml
+++ b/config/sync/core.entity_view_display.node.blog.search_result.yml
@@ -37,3 +37,5 @@ content:
     weight: 100
 hidden:
   body: true
+  field_caption: true
+  upload: true

--- a/config/sync/core.entity_view_display.node.blog.teaser.yml
+++ b/config/sync/core.entity_view_display.node.blog.teaser.yml
@@ -35,4 +35,6 @@ content:
   links:
     weight: 100
 hidden:
+  field_caption: true
   field_image: true
+  upload: true

--- a/config/sync/field.field.node.news.upload.yml
+++ b/config/sync/field.field.node.news.upload.yml
@@ -19,7 +19,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: content/pdfs/news
-  file_extensions: pdf
+  file_extensions: 'pdf mp3'
   max_filesize: 25MB
   description_field: true
   handler: 'default:file'

--- a/config/sync/imce.profile.member.yml
+++ b/config/sync/imce.profile.member.yml
@@ -8,7 +8,7 @@ id: member
 label: 'Editor profile'
 description: 'Configuration for editors'
 conf:
-  extensions: 'jpg jpeg png gif pdf'
+  extensions: 'jpg jpeg png gif pdf mp3'
   maxsize: !!float 10
   quota: !!float 0
   maxwidth: 1212


### PR DESCRIPTION
…r file upload for Editors and News items. Also included in this commit is some field changes to a deprecated content type (Blog); these can be ignored, but should be updated to avoid YML conflicts in the future.
